### PR TITLE
Handle multiple series/meters from a single meter

### DIFF
--- a/internal/app/metrics.go
+++ b/internal/app/metrics.go
@@ -29,6 +29,9 @@ func WriteMetrics(records []ElectricUsage, config InfluxConfig) error {
 			if record.CostInCents != nil {
 				point.AddField("cost", float64(*record.CostInCents)/minutes)
 			}
+			if record.MeterName != nil {
+				point.AddTag("name", *record.MeterName)
+			}
 			points = append(points, point)
 		}
 		err := writeApi.WritePoint(context.Background(), points...)


### PR DESCRIPTION
- For some meters, there can be separate consumption and generation series/meters. See #7
- This change adds a tag "name" to the metric if more than one series is returned.
  - If the name has a format like "1234 - Consumption", the characters after the last space will be used as the name.

Fixes #7